### PR TITLE
Add 'static' feature to enable libwebp-sys2/static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ features = ["0_5", "0_6", "1_2", "demux", "mux"]
 image = { version = "0.23.14" }
 imageproc = { version = "0.22.0" }
 env_logger = "0.8.3"
+
+[features]
+static = ["libwebp-sys2/static"]


### PR DESCRIPTION
This feature enables static linking of the webp libraries. The libwebp-sys2 create will already fallback to static linking if it doesn't find system-wide webp libraries, but this allows static linking to be explicit.