### PR TITLE
impl Send/Sync for WebPData

### DIFF
--- a/src/webp_data.rs
+++ b/src/webp_data.rs
@@ -28,6 +28,14 @@ impl WebPData {
     }
 }
 
+/// SAFETY: Sending `WebPData` to another thread is safe until there is no way to share internal
+/// pointer without borrowing in safe code
+unsafe impl Send for WebPData {}
+
+/// SAFETY: Sharing `WebPData` via borrowing is safe until there is no way to share internal
+/// pointer without borrowing in safe code
+unsafe impl Sync for WebPData {}
+
 impl Drop for WebPData {
     fn drop(&mut self) {
         unsafe { libwebp_sys::WebPDataClear(self.inner_ref()) }


### PR DESCRIPTION
It is very hard to use current `WebPData` in async runtime. On the other hand currently there is no reason for `WebPData` not to implement `Send` and `Sync`.