### PR TITLE
Fix pixel size for `Rgb` and `Bgr` modes

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, mem, pin::Pin};
 
 use libwebp_sys as webp;
 
-use crate::{ColorMode, Error, Frame, PIXEL_BYTES};
+use crate::{ColorMode, Error, Frame};
 
 const MAX_CANVAS_SIZE: usize = 3840 * 2160; // 4k
 
@@ -260,10 +260,11 @@ impl<'a> Iterator for DecoderIterator<'a> {
         }
 
         let info = &self.animation_decoder.info;
+        let opts = &self.animation_decoder.options;
         let data = unsafe {
             std::slice::from_raw_parts(
                 output_buffer,
-                info.canvas_width as usize * info.canvas_height as usize * PIXEL_BYTES,
+                info.canvas_width as usize * info.canvas_height as usize * opts.color_mode.size(),
             )
         };
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2,9 +2,7 @@ use std::{mem, pin::Pin, ptr};
 
 use libwebp_sys as webp;
 
-use crate::{
-    ColorMode, ConfigContainer, EncoderOptions, EncodingConfig, Error, WebPData, PIXEL_BYTES,
-};
+use crate::{ColorMode, ConfigContainer, EncoderOptions, EncodingConfig, Error, WebPData};
 
 #[allow(unused_imports)]
 use crate::LossyEncodingConfig; // for docs
@@ -328,7 +326,7 @@ impl PictureWrapper {
 
     pub fn set_data(&mut self, data: &[u8], color_mode: ColorMode) -> Result<(), Error> {
         let received_len = data.len();
-        let expected_len = self.data_size();
+        let expected_len = self.data_size(color_mode);
         if received_len != expected_len {
             return Err(Error::BufferSizeFailed(expected_len, received_len));
         }
@@ -364,8 +362,8 @@ impl PictureWrapper {
         Ok(())
     }
 
-    fn data_size(&self) -> usize {
-        self.picture.width as usize * self.picture.height as usize * PIXEL_BYTES
+    fn data_size(&self, color_mode: ColorMode) -> usize {
+        self.picture.width as usize * self.picture.height as usize * color_mode.size()
     }
 }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use image::ImageBuffer;
 
 #[allow(unused_imports)]
-use crate::{ColorMode, Decoder, Error, PIXEL_BYTES};
+use crate::{ColorMode, Decoder, Error};
 
 /// An animation frame containing data and metadata produced by [`Decoder`]
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,6 @@ pub mod prelude {
     pub use crate::{Encoder, EncoderOptions, EncodingConfig, EncodingType, LossyEncodingConfig};
 }
 
-const PIXEL_BYTES: usize = 4;
-
 /// Color Mode that configures the output type of [`Decoder`] [`Frame`]'s
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ColorMode {
@@ -48,6 +46,17 @@ pub enum ColorMode {
     Bgra,
     // Bgr (blue, green, red) - no alpha
     Bgr,
+}
+
+impl ColorMode {
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Rgb => 3,
+            Self::Rgba => 4,
+            Self::Bgra => 4,
+            Self::Bgr => 3,
+        }
+    }
 }
 
 /// Error type produced by `webp_animation` code


### PR DESCRIPTION
Fix the issue where it's impossible to process images in `RGB` and `BGR` formats, even if you directly set this format.